### PR TITLE
Add QR generation CLI with metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # avook-qr
+
+CLI utility to generate QR codes with an embedded logo and matching metadata.
+
+```
+python3 generate_qr.py
+```
+
+The script prompts for QR details and metadata. Press **Enter** to accept
+the defaults:
+
+- Base URL: `https://audiovook.com/qr/code/`
+- QR image filename: `qrlogo.png`
+
+The final QR encodes the base URL plus a generated unique code and writes a
+JSON file alongside the image in `original/OUTPUT/`.

--- a/generate_qr.py
+++ b/generate_qr.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import datetime
+import pathlib
+import uuid
+
+
+def main():
+    default_url = "https://audiovook.com/qr/code/"
+    default_image = "qrlogo.png"
+
+    base_url = (
+        input(f"Base URL (ex: https://my.domain/qr/) [{default_url}]: ").strip()
+        or default_url
+    )
+    img_name = (
+        input(f"Nom d'imatge per al QR (ex: product1.png) [{default_image}]: ").strip()
+        or default_image
+    )
+    product_id = input("ID de producte: ").strip()
+    in_shop = input("És en una botiga? (s/n): ").lower().startswith("s")
+    shop_id = input("ID de botiga (en blanc si no): ").strip()
+
+    unique_code = uuid.uuid4().hex[:12]
+    final_url = f"{base_url}{unique_code}"
+    print(f"Generating QR code for: {final_url}")
+
+    subprocess.run(
+        ["./QR-generate.sh", "--url", final_url, "-o", img_name],
+        cwd="original",
+        check=True,
+    )
+
+    metadata = {
+        "qr_image_name": img_name,
+        "product_id": product_id,
+        "date_generation": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "is_in_shop": in_shop,
+        "shop_id": shop_id or None,
+        "unique_code": unique_code,
+        "final_url": final_url,
+    }
+
+    out_dir = pathlib.Path("original/OUTPUT")
+    out_dir.mkdir(exist_ok=True)
+    json_path = out_dir / f"{pathlib.Path(img_name).stem}.json"
+    json_path.write_text(json.dumps(metadata, indent=2))
+    print("QR i metadades creats.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- set default base URL https://audiovook.com/qr/code/
- default QR image name qrlogo.png
- append unique code to base URL and document usage

## Testing
- `python3 generate_qr.py` *(fails: qrencode, convert, identify, composite: command not found)*
- `python -m py_compile generate_qr.py`


------
https://chatgpt.com/codex/tasks/task_e_68aee845f938832e8e50ee15bcccf8a8